### PR TITLE
Move import settings to OnConfigRegister for more reliable triggering.

### DIFF
--- a/Scripts/Source/OSexIntegrationMCM.psc
+++ b/Scripts/Source/OSexIntegrationMCM.psc
@@ -244,10 +244,11 @@ Function Init()
 	pagearr = PapyrusUtil.PushString(pagearr, "$ostim_page_about")
 
 	Pages = pagearr
-
-	Utility.Wait(2)
-	ImportSettings()
 EndFunction
+
+Event OnConfigRegister()
+	ImportSettings()
+endEvent
 
 Event OnPageReset(String Page)
 	{Called when a new page is selected, including the initial empty page}


### PR DESCRIPTION
Might also resolve the empty MCM menu bug some people have been having, I have a gut feeling that might be linked to the old 2 second wait.