### PR TITLE
Compatibility with Precision mod

### DIFF
--- a/OStim_CI.ppj
+++ b/OStim_CI.ppj
@@ -19,17 +19,18 @@
         <Import>https://github.com/MrOctopus/nl_online/tree/main/jcontainersse/source</Import>
         <Import>https://github.com/eeveelo/PapyrusUtil/tree/master/Scripts/Source</Import>
         <Import>https://github.com/CE0/OSA-SE/tree/master/Data/Scripts/Source</Import>
-        <Import>https://github.com/Osmosis-Wrench/random-loose-scripts/tree/main/scripts/source</Import>
+        <Import>https://github.com/Osmosis-Wrench/racemenu-scripts/tree/main/scripts/source</Import>
         <Import>https://github.com/MrOctopus/nl_online/tree/main/skyui/source</Import>
         <Import>https://github.com/MrOctopus/nl_online/tree/main/skse64/source</Import>
         <Import>https://github.com/MrOctopus/nl_online/tree/main/sse/source</Import>
+        <Import>https://github.com/ersh1/Precision/tree/main/scripts/source</Import>
     </Imports>
     <Folders>
         <Folder>@MyProject\Scripts\Source</Folder>
     </Folders>
     <ZipFiles Output="@Dist">
         <ZipFile Name="@ModName" RootDir="@MyProject" Compression="deflate">
-        	<Include NoRecurse="true">*.esp</Include>
+            <Include NoRecurse="true">*.esp</Include>
             <Include>Scripts</Include>
             <Include>SKSE</Include>
             <Include>Interface</Include>

--- a/Scripts/Source/OSexIntegrationMain.psc
+++ b/Scripts/Source/OSexIntegrationMain.psc
@@ -434,6 +434,16 @@ Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zU
 		endif 
 	endif 
 
+	; Disable Precision mod collisions for the actors involved to prevent misalignments and teleports to (0,0) cell
+	TogglePrecisionForActor(DomActor, false)
+
+	If SubActor
+		TogglePrecisionForActor(SubActor, false)
+	EndIf
+
+	If ThirdActor
+		TogglePrecisionForActor(ThirdActor, false)
+	EndIf
 
 	If (Aggressive)
 		If (AggressingActor)
@@ -926,6 +936,17 @@ Event OnUpdate() ;OStim main logic loop
 
 	oldscenemetadata = scenemetadata
 	scenemetadata = PapyrusUtil.StringArray(0)
+
+	; Enable Precision mod collisions for the actors involved again
+	TogglePrecisionForActor(DomActor, true)
+
+	If (SubActor)
+		TogglePrecisionForActor(SubActor, true)
+	EndIf
+
+	If (ThirdActor)
+		TogglePrecisionForActor(ThirdActor, true)
+	EndIf
 
 	SceneRunning = False
 
@@ -2108,6 +2129,8 @@ Function OnAnimationChange()
 
 			If (Act != DomActor) && (Act != SubActor) && (IsActorActive(Act))
 				ThirdActor = Act
+				; Disable Precision mod collisions for the third actor to prevent misalignments and teleports to (0,0) cell
+				TogglePrecisionForActor(ThirdActor, false)
 				i = max
 			Endif
 			i += 1
@@ -2142,6 +2165,9 @@ Function OnAnimationChange()
 		if !DisableScaling
 			ThirdActor.SetScale(1.0)
 		EndIf
+
+		; Enable Precision mod collisions again for the actor that is leaving
+		TogglePrecisionForActor(ThirdActor, true)
 
 		ThirdActor = none
 
@@ -3297,6 +3323,25 @@ EndFunction
 
 Bool Function GetGameIsVR()
 	Return (PapyrusUtil.GetScriptVersion() == 36) ;obviously this no guarantee but it's the best we've got for now
+EndFunction
+
+Function TogglePrecisionForActor(Actor Act, bool Enable)
+	; Wrapper function to toggle Precision On or Off for the given Actor if Precision is installed
+	; if Enable is True, Precision will be enabled for the given Actor
+	; if Enable is False, Precision will be disabled for the given Actor
+	; if Actor has Precision enabled and Enable is True, this function won't call Precision Utility
+	; the same happens if Actor has Precision disabled and Enable is False
+	If (IsModLoaded("Precision.esp"))
+		If (Precision_Utility.IsActorActive(Act) != Enable)
+			Precision_Utility.ToggleDisableActor(Act, !Enable)
+			
+			If (Enable)
+				Console("Precision was re-enabled for actor " + Act.GetActorBase().GetName())
+			Else
+				Console("Precision was disabled for actor " + Act.GetActorBase().GetName())
+			EndIf
+		EndIf
+	EndIf
 EndFunction
 
 Function AcceptReroutingActors(Actor Act1, Actor Act2) ;compatibility thing, never call this one directly


### PR DESCRIPTION
As of the latest versions of [Precision](https://www.nexusmods.com/skyrimspecialedition/mods/72347), OStim became incompatible with this mod - a number of artifacts started happening, namely the actors being teleported to the (0,0) cell and misalignment issues.

The real cause for this is still unknown, but the author of Precision introduced a function in his mod to disable his mod's collisions for a given actor.

Disabling Precision collisions for the actors involved before an OStim scene starts fixes the problems above, therefore making OStim again compatible with Precision until the real cause of the problem is found and fixed.

When the OStim scene ends, Precision collisions are once again enabled for the actors involved.

The PPJ build file was also updated so that OStim can be properly compiled with it.