### PR TITLE
Small improvements to actor scan for starting threesomes

### DIFF
--- a/Scripts/Source/OSexIntegrationMain.psc
+++ b/Scripts/Source/OSexIntegrationMain.psc
@@ -2036,14 +2036,13 @@ Function OnAnimationChange()
 	If (!ThirdActor && (CorrectActorCount == 3)) ; no third actor, but there should be
 		Console("Third actor has joined scene ")
 
-		Actor[] NearbyActors = MiscUtil.ScanCellNPCs(DomActor, Radius = 64.0) ;epic hackjob time
-		int max = NearbyActors.Length
+		int max = OControl.ActraInRange.Length
 		int i = 0
 
 		While (i < max)
-			Actor Act = NearbyActors[i]
+			Actor Act = OControl.ActraInRange[i]
 
-			If (Act != DomActor) && (Act != SubActor) && (IsActorActive(Act))
+			If (Act) && (Act != DomActor) && (Act != SubActor) && (IsActorActive(Act))
 				ThirdActor = Act
 				OSANative.AddThirdActor(Password, ThirdActor)
 				; Disable Precision mod collisions for the third actor to prevent misalignments and teleports to (0,0) cell

--- a/Scripts/Source/_oControl.psc
+++ b/Scripts/Source/_oControl.psc
@@ -27,6 +27,8 @@ Int Property osaEndKey = 83 auto ; numpad .
 
 Bool property disableControl auto
 
+Actor[] property ActraInRange auto
+
 Armor[] InspectArmor
 Int[] InspectArmorWorn
 
@@ -401,45 +403,31 @@ Event OnTargeting(String EventName, String Query, Float NumArg, Form Sender)
         ; Potentially a spell cloak could be used but that sounds like it might be even more expensive.
 
         Actor ActraFound
-        Actor[] ActraFoundArr = new Actor[25]
+        ActraInRange = PapyrusUtil.ActorArray(30)
 
         Int i = 0
-        Int ScanAmount = 25
+        Int ScanAmount = 30
         Int FoundCount = 0
+
         While (i < ScanAmount)
             ActraFound = Game.FindRandomActorFromRef(PlayerRef, 5000.0)
-            If (ActraFoundArr.Find(ActraFound) == -1)
-                ;PapyrusUtil.PushActor(actraInRange, actorFound)
-                ActraFoundArr[i] = ActraFound
+
+            If (ActraFound && !ActraFound.isChild() && ActraFound.HasKeywordString("ActorTypeNPC") && ActraInRange.Find(ActraFound) == -1)
+                ActraInRange[FoundCount] = ActraFound
                 FoundCount += 1
             EndIf
             i += 1
         endWhile
-
-        Actor[] ActraInRange = PapyrusUtil.ActorArray(FoundCount)
-
-        i = 0
-        Int FoundCountAdded = 0
-        While (i < ScanAmount)
-            If (ActraFoundArr[i])
-                ActraInRange[FoundCountAdded] = ActraFoundArr[i]
-                FoundCountAdded += 1
-            EndIf
-            i += 1
-        EndWhile
 
         ; END OF SHITTY BAND-AID
 
         Debug.Notification("Scan Done")
 
         i = 0
-        Int L = ActraInRange.Length
-        While i < L
-            If (ActraInRange[i].HasKeywordString("ActorTypeNPC"))
-                IDs = GetFormID_S(ActraInRange[i].GetActorBase())
-                OSO.ProcessActraDetails(ActraInRange[i], IDs)
-                UI.InvokeString("HUD Menu", "_root.WidgetContainer." + Glyph + ".widget.targ.addTarg", IDs)
-            EndIf
+        While i < FoundCount
+            IDs = GetFormID_S(ActraInRange[i].GetActorBase())
+            OSO.ProcessActraDetails(ActraInRange[i], IDs)
+            UI.InvokeString("HUD Menu", "_root.WidgetContainer." + Glyph + ".widget.targ.addTarg", IDs)
             i += 1
         EndWhile
 


### PR DESCRIPTION
- Increase scan amount from 25 to 30: this helped find more actors from my tests with no noticeable performance impact
- Make ActraInRange a property that can be used in OSexIntegrationMain, so that ScanCellNPCs doesn't have to be called again
- Don't let children be found by the scan
- There is now only one array for the actors found instead of three different arrays