### PR TITLE
Fix infinite fade to black screen when end scene key is pressed with no scene running

### DIFF
--- a/Scripts/Source/_oControl.psc
+++ b/Scripts/Source/_oControl.psc
@@ -92,8 +92,8 @@ Event OnKeyDown(Int KeyPress)
         Return
     EndIf
 
-    If (KeyPress == OKey[0])
-        ostim.EndAnimation(true)        
+    If (KeyPress == OKey[0] && ostim.AnimationRunning())
+        ostim.EndAnimation(true)
     ElseIf disableControl
         If !Utility.IsInMenuMode()
             OsexIntegrationMain.Console("OSA controls disabled by OStim property")


### PR DESCRIPTION
If you start an OStim scene, end it with the end scene key, and then press the end scene key again, OStim will go into an infinite fade to black screen, since a call to AnimationRunning() was missing from the OnKeyDown event in _oControl.psc

The animation running check could also be moved to the EndAnimation() function itself, I'm open to suggestions :)