### PR TITLE
Small fix to manual start

### DIFF
--- a/Scripts/Source/OSexIntegrationMain.psc
+++ b/Scripts/Source/OSexIntegrationMain.psc
@@ -884,7 +884,7 @@ Event OnUpdate() ;OStim main logic loop
 
 	SendModEvent("ostim_start")
 
-	
+
 	If (UseFades && IsPlayerInvolved())
 		FadeFromBlack()
 	EndIf
@@ -3035,9 +3035,9 @@ Event OnKeyDown(Int KeyPress)
 			If (Target.IsInDialogueWithPlayer())
 				Return
 			EndIf
-			If (!Target.IsDead())
+			If (!Target.IsDead() && !Target.isChild() && Target.HasKeywordString("ActorTypeNPC"))
 				AddSceneMetadata("ostim_manual_start")
-				StartScene(PlayerRef,  Target)
+				StartScene(PlayerRef, Target)
 				return 
 			EndIf
 		Else


### PR DESCRIPTION
When pressing the Up Arrow, the only check done on the target is if it's dead or not. This means that if you, for instance, accidentally use the up arrow on a summon or any other invalid target, OStim goes into an infinite fade to black.

Fix this by adding more checks to the manual start.