### PR TITLE
OStim Subthreads rewrite and improvements

### DIFF
--- a/Scripts/Source/OAIUtils.psc
+++ b/Scripts/Source/OAIUtils.psc
@@ -1,0 +1,97 @@
+ScriptName OAIUtils
+
+; Common shared functions for AI (auto mode and NPC on NPC scenes)
+
+String Function GetRandomForeplayAnimation(Actor[] Actors, string FurnitureType, int Aggressor = -1, bool isAggressorFemale, bool isLesbian, bool isGay) Global
+	string typesAny = ""
+	string typesBlacklist = "analsex,tribbing,vaginalsex"
+
+	string standingTag = ""
+	If FurnitureType == ""
+		standingTag = OCSV.CreateCSVMatrix(Actors.Length, "standing")
+	EndIf
+
+	string actorTagBlacklist = ""
+	If FurnitureType == "bed"
+		actorTagBlacklist = OCSV.CreateCSVMatrix(Actors.Length, "standing")
+	EndIf
+
+	string sceneTags = ""
+	if isLesbian
+		sceneTags = "lesbian"
+	elseif isGay
+		sceneTags = "gay"
+	endif
+
+	If Aggressor != -1
+		string id = ""
+		string aggSceneTags = OCSV.ConcatCSVLists(sceneTags, "aggressive")
+		string aggressorTag = OCSV.CreateSingleCSVMatrixEntry(Aggressor, "aggressor")
+		string aggressorList = OCSV.CreateCSVList(4, Aggressor)
+
+		OSexIntegrationMain OStim = OUtils.GetOStim()
+		If isAggressorFemale
+			id = OLibrary.GetRandomSceneSuperloadCSV(Actors, FurnitureType, AllSceneTags = aggSceneTags, AnyActorTagForAny = standingTag, AllActorTagsForAll = aggressorTag, ActorTagBlacklistForAll = actorTagBlacklist, AnyActionType = "cunnilingus,grindingthigh", AnyActionActor = "," + Aggressor, AnyActionTarget = Aggressor, AnyActionPerformer = AggressorList, ActionBlacklistTypes = typesBlacklist)
+		Else
+			id = OLibrary.GetRandomSceneSuperloadCSV(Actors, FurnitureType, AllSceneTags = aggSceneTags, AnyActorTagForAny = standingTag, AllActorTagsForAll = aggressorTag, ActorTagBlacklistForAll = actorTagBlacklist, AnyActionType = "blowjob,boobjob,buttjob,thighjob", AnyActionTarget = AggressorList, AnyActionPerformer = AggressorList, ActionBlacklistTypes = typesBlacklist)
+		EndIf
+
+		If id != ""
+			Return id
+		EndIf
+	EndIf
+
+	Return OLibrary.GetRandomSceneSuperloadCSV(Actors, FurnitureType, AllSceneTags = sceneTags, AnyActorTagForAny = standingTag, ActorTagBlacklistForAll = actorTagBlacklist, AnyActionType = "analfingering,blowjob,boobjob,buttjob,cunnilingus,footjob,grindingthigh,handjob,lickingnipples,lickingpenis,lickingtesticles,rimjob,rubbingclitoris,rubbingpenisagainstface,suckingnipples,thighjob,vaginalfingering", ActionBlacklistTypes = typesBlacklist)
+EndFunction
+
+String Function GetRandomSexAnimation(Actor[] Actors, string FurnitureType, int Aggressor = -1, bool isLesbian, bool isGay) Global
+	string typesAny = "analsex,vaginalsex"
+
+	string standingTag = ""
+	If FurnitureType == ""
+		standingTag = OCSV.CreateCSVMatrix(Actors.Length, "standing")
+	EndIf
+
+	string actorTagBlacklist = ""
+	If FurnitureType == "bed"
+		actorTagBlacklist = OCSV.CreateCSVMatrix(Actors.Length, "standing")
+	EndIf
+
+	string sceneTags = ""
+	if isLesbian
+		sceneTags = "lesbian"
+		typesAny += ",tribbing"
+	elseif isGay
+		sceneTags = "gay"
+	endif
+
+	If Aggressor != -1
+		string aggSceneTags = OCSV.ConcatCSVLists(sceneTags, "aggressive")
+		string aggressorTag = OCSV.CreateSingleCSVMatrixEntry(Aggressor, "aggressor")
+		string aggressorList = OCSV.CreateCSVList(3, Aggressor)
+
+		string id = OLibrary.GetRandomSceneSuperloadCSV(Actors, FurnitureType, AllSceneTags = aggSceneTags, AnyActorTagForAny = standingTag, AllActorTagsForAll = aggressorTag, ActorTagBlacklistForAll = actorTagBlacklist, AnyActionType = typesAny, AnyActionPerformer = AggressorList)
+
+		If id != ""
+			Return id
+		EndIf
+	EndIf
+
+	Return OLibrary.GetRandomSceneSuperloadCSV(Actors, FurnitureType, AllSceneTags = sceneTags, AnyActorTagForAny = standingTag, ActorTagBlacklistForAll = actorTagBlacklist, AnyActionType = typesAny)
+EndFunction
+
+String Function GetPulledOutVersion(Actor[] Actors, string FurnitureType, string SceneID, string[] positionTags) Global
+	OSexIntegrationMain.Console("trying pullout")
+
+	string[] ActorTags = PapyrusUtil.StringArray(Actors.Length)
+
+	int i = Actors.Length
+	While i
+		i -= 1
+		ActorTags[i] = OCSV.ToCSVList(OMetadata.GetActorTagOverlap(SceneID, i, positionTags)) ; get position tags
+	EndWhile
+
+	string ActorTagsCSV = OCSV.ToCSVMatrix(ActorTags)
+
+	return OLibrary.GetRandomSceneSuperloadCSV(Actors, FurnitureType, AllActorTagsForAll = ActorTagsCSV, AnyActionType = "malemasturbation", AnyActionActor = "0")
+EndFunction

--- a/Scripts/Source/OSexIntegrationMain.psc
+++ b/Scripts/Source/OSexIntegrationMain.psc
@@ -592,15 +592,20 @@ Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zU
 	if !installed 
 		debug.Notification("OStim not ready or installation failed")
 		return false
-	endif 
+	endif
+
+	; If Player isn't involved, it's an NPC scene, so start it on a subthread instead
+	If PlayerRef != Dom && PlayerRef != Sub && PlayerRef != zThirdActor
+		if !GetUnusedSubthread().StartSubthreadScene(Dom, Sub, zThirdActor = zThirdActor, startingAnimation = zStartingAnimation, furnitureObj = Bed, withAI = true, isAggressive = Aggressive, aggressingActor = AggressingActor)
+			Debug.Notification("OStim: Thread overload, please report this on discord")
+			return False
+		endif 
+		return True
+	EndIf
 
 	If (SceneRunning)
-		if IsNPCScene()
-			ConvertToSubthread()
-		else 
-			Debug.Notification("OSA scene already running")
-			Return False
-		endif 
+		Debug.Notification("OSA scene already running")
+		Return False
 	EndIf
 
 	If IsActorActive(dom) || (sub && IsActorActive(sub))
@@ -609,7 +614,7 @@ Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zU
 	EndIf
 	If !dom.Is3DLoaded()
 		console("Dom actor is not loaded")
-		return false
+		return False
 	EndIf
 
 	; Default OSex gender order
@@ -635,7 +640,7 @@ Bool Function StartScene(Actor Dom, Actor Sub, Bool zUndressDom = False, Bool zU
 	EndIf
 
 
-	If SubActor && IsPlayerInvolved()
+	If SubActor
 		;special reordering settings
 		;todo: clean up all of the ordering code around here
 		bool gay = (AppearsFemale(dom) == AppearsFemale(sub))
@@ -743,28 +748,26 @@ EndFunction
 Event OnUpdate() ;OStim main logic loop
 	Console("Starting scene asynchronously")
 
-	If IsPlayerInvolved()
-		OSANative.EndPlayerDialogue()
+	OSANative.EndPlayerDialogue()
 
-		bool InDialogue = false
-		int i = Actors.Length
+	bool InDialogue = false
+	int i = Actors.Length
+	While i
+		i -= 1
+		InDialogue = InDialogue || Actors[i].IsInDialogueWithPlayer()
+	EndWhile
+
+	While InDialogue
+		InDialogue = false
+		Utility.Wait(0.3)
+		i = Actors.Length
 		While i
 			i -= 1
 			InDialogue = InDialogue || Actors[i].IsInDialogueWithPlayer()
 		EndWhile
+	EndWhile
 
-		While InDialogue
-			InDialogue = false
-			Utility.Wait(0.3)
-			i = Actors.Length
-			While i
-				i -= 1
-				InDialogue = InDialogue || Actors[i].IsInDialogueWithPlayer()
-			EndWhile
-		EndWhile
-	EndIf
-
-	If (UseFades && IsPlayerInvolved())
+	If (UseFades)
 		FadeToBlack()
 	EndIf
 
@@ -783,7 +786,7 @@ Event OnUpdate() ;OStim main logic loop
 
 	SendModEvent("ostim_prestart") ; fires as soon as the screen goes black. be careful, some settings you normally expect may not be set yet. Use ostim_start to run code when the OSA scene begins.
 
-	If (EnableImprovedCamSupport) && IsPlayerInvolved()
+	If (EnableImprovedCamSupport)
 		Game.DisablePlayerControls(abCamswitch = True, abMenu = False, abFighting = False, abActivate = False, abMovement = False, aiDisablePOVType = 0)
 	EndIf
 
@@ -832,7 +835,7 @@ Event OnUpdate() ;OStim main logic loop
 			SelectFurniture()
 		Else
 			CurrentFurniture = FindBed(Actors[0])
-			If CurrentFurniture && (!SelectFurniture || !IsPlayerInvolved() || OStimBedConfirmationMessage.Show() == 0)
+			If CurrentFurniture && (!SelectFurniture || OStimBedConfirmationMessage.Show() == 0)
 				FurnitureType == FURNITURE_TYPE_BED
 			Else
 				CurrentFurniture = None
@@ -885,6 +888,7 @@ Event OnUpdate() ;OStim main logic loop
 	;profile()
 
 	CurrScene = OSA.MakeStage()
+	Password = CurrScene[0] as int
 	OSA.SetActorsStim(currScene, Actors)
 	OSA.SetModule(CurrScene, "0Sex", StartingAnimation, "")
 	OSA.StimStart(CurrScene)
@@ -893,14 +897,7 @@ Event OnUpdate() ;OStim main logic loop
 
 	; "Diasa" is basically an OSA scene thread. We need to mount it here so OStim can communicate with OSA.
 	; (I didn't pick the nonsense name, it's called that in OSA)
-	; Unfortunately, the method used for mounting an NPC on NPC scene is a bit involved.
-	if IsNPCScene()
-		diasa = GetNPCDiasa(DomActor)
-		Console("Scene is a NPC on NPC scene")
-		disableOSAControls = true
-	Else
-		diasa = o + ".viewStage"
-	endif
+	diasa = o + ".viewStage"
 
 	CurrentAnimation = ""
 	CurrentSceneID = StartingAnimation
@@ -909,8 +906,7 @@ Event OnUpdate() ;OStim main logic loop
 
 	Int OldTimescale = 0
 
-;	If (CustomTimescale >= 1) && IsPlayerInvolved()
-	If (CustomTimescale > 0) && IsPlayerInvolved()
+	If (CustomTimescale > 0)
 		OldTimescale = GetTimeScale()
 		SetTimeScale(CustomTimescale)
 		Console("Using custom Timescale: " + CustomTimescale)
@@ -925,7 +921,6 @@ Event OnUpdate() ;OStim main logic loop
 		EndIf
 	EndIf
 
-	Password = DomActor.GetFactionRank(OsaFactionStage)
 	OSANative.StartScene(Password, Actors)
 	string EventName = "0SAO" + Password + "_AnimateStage"
 	RegisterForModEvent(eventName, "OnAnimate")
@@ -961,10 +956,6 @@ Event OnUpdate() ;OStim main logic loop
 			Console("Masturbation scene detected. Starting AI")
 			AI.StartAI()
 			AIRunning = True
-		ElseIf (SubActor && IsNPCScene() && UseAINPConNPC)
-			Console("NPC on NPC scene detected. Starting AI")
-			AI.StartAI()
-			AIRunning = True
 		ElseIf (SubActor && (AggressiveActor == PlayerRef) && UseAIPlayerAggressor)
 			Console("Player aggressor. Starting AI")
 			AI.StartAI()
@@ -989,9 +980,8 @@ Event OnUpdate() ;OStim main logic loop
 
 
 	SendModEvent("ostim_start")
-
-
-	If (UseFades && IsPlayerInvolved())
+	
+	If (UseFades)
 		FadeFromBlack()
 	EndIf
 
@@ -1047,7 +1037,7 @@ Event OnUpdate() ;OStim main logic loop
 	Console("Ending scene")
 
 
-	int i = Actors.Length
+	i = Actors.Length
 	While i
 		i -= 1
 
@@ -1064,7 +1054,7 @@ Event OnUpdate() ;OStim main logic loop
 		RestoreScales()
 	EndIf
 
-	If (EnableImprovedCamSupport) && IsPlayerInvolved()
+	If (EnableImprovedCamSupport)
 		Game.EnablePlayerControls(abCamSwitch = True)
 	EndIf
 
@@ -1081,7 +1071,7 @@ Event OnUpdate() ;OStim main logic loop
 			SubActor.StopTranslation()
 			SubActor.SetPosition(subcoords[0], subcoords[1], subcoords[2]) ;return
 		EndIf
-		If (UseFades && EndedProper && IsPlayerInvolved())
+		If (UseFades && EndedProper)
 			Game.FadeOutGame(False, True, 25.0, 25.0) ; keep the screen black
 		EndIf
 	EndIf
@@ -1090,8 +1080,7 @@ Event OnUpdate() ;OStim main logic loop
 		OFurniture.ResetClutter(CurrentFurniture, ResetClutterRadius * 100)
 	EndIf
 
-	If (ForceFirstPersonAfter && IsPlayerInvolved())
-
+	If (ForceFirstPersonAfter)
 		While IsInFreeCam()
 			Utility.Wait(0.1)
 		EndWhile
@@ -1099,7 +1088,7 @@ Event OnUpdate() ;OStim main logic loop
 		Game.ForceFirstPerson()
 	EndIf
 
-	If (UseFades && EndedProper && IsPlayerInvolved() && !SkipEndingFadein)
+	If (UseFades && EndedProper && !SkipEndingFadein)
 		FadeFromBlack(2)
 	EndIf
 
@@ -1135,15 +1124,18 @@ Event OnUpdate() ;OStim main logic loop
 	OSANative.EndScene(Password)
 	SendModEvent("ostim_totalend")
 
+	Password = 0
+
 	If (FurnitureType != FURNITURE_TYPE_NONE)
 		CurrentFurniture.BlockActivation(false)
 		FurnitureType = FURNITURE_TYPE_NONE
 		CurrentFurniture = None
 	EndIf
 
-	If IsPlayerInvolved()
-		OSANative.EndPlayerDialogue()
-	EndIf
+	FurnitureType = 0
+	CurrentFurniture = none
+
+	OSANative.EndPlayerDialogue()
 
 EndEvent
 
@@ -1197,13 +1189,9 @@ Bool Function IsActorInvolved(actor act)
 	Return Actors.Find(act) >= 0
 EndFunction
 
-Bool Function IsPlayerInvolved()
-	return IsActorInvolved(playerref)
-EndFunction
-
-Bool Function IsNPCScene()
-	return !IsPlayerInvolved()
-EndFunction
+int Function GetScenePassword()
+	return Password
+endfunction
 
 Bool Function IsSoloScene()
 	return SubActor == None
@@ -1408,18 +1396,13 @@ Function ToggleActorAI(bool enable)
 EndFunction
 
 Function EndAnimation(Bool SmoothEnding = True)
-	If (AnimationRunning() && UseFades && SmoothEnding && IsPlayerInvolved())
+	If (AnimationRunning() && UseFades && SmoothEnding)
 		FadeToBlack(1.5)
 	EndIf
 	EndedProper = SmoothEnding
-	Console("Trying to end scene")	
+	Console("Trying to end scene")
 
-	If (IsNPCScene() && (Actors[0].GetParentCell() != playerref.GetParentCell()))
-		; Attempting to end the scene when the actors are not loaded will fail
-		SendModEvent("0SA_GameLoaded")
-	else 
-		UI.Invoke("HUD Menu", diasa + ".endCommand")
-	endif 
+	UI.Invoke("HUD Menu", diasa + ".endCommand")
 EndFunction
 
 Bool Function IsSceneAggressiveThemed() ; if the entire situation should be themed aggressively
@@ -1609,30 +1592,6 @@ Function AllowVehicleReset()
 	EndWhile
 EndFunction
 
-
-;Is this even used or necessary?
-float function GetEstimatedTimeUntilEnd()
-	float total = 120
-	total /= MaleSexExcitementMult ; This will no longer work
-
-	float dom = 99999.0
-	float sub = 99999.0
-
-	if EndOnDomOrgasm
-		dom = total * (1 - (GetActorExcitement( DomActor)/100.0))
-	endif 
-	if EndOnSubOrgasm
-		sub = total * (1 - (GetActorExcitement( SubActor)/100.0))
-	endif 
-
-	if sub < dom
-		return sub
-	else 
-		return dom
-	endif
-
-EndFunction
-
 Function ToggleFreeCam(Bool On = True)
 	outils.lock("mtx_tfc")
 
@@ -1810,22 +1769,6 @@ OStimSubthread Function GetSubthread(int id)
 	return ret
 EndFunction
 
-Function ConvertToSubthread()
-{Turn the current thread into a subthread and wait to return}
-	if SceneRunning
-		if !GetUnusedSubthread().InheritFromMain()
-			Debug.Notification("OStim: Thread overload, please report this on discord")
-		endif 
-
-		while SceneRunning
-			Utility.Wait(0.5)
-		endwhile 
-		Utility.Wait(1.0)
-	else 
-		Console("Nothing running...")
-	endif 
-EndFunction
-
 float Function GetTimeSinceStart()
 	return Utility.GetCurrentRealTime() - StartTime
 EndFunction
@@ -1842,7 +1785,7 @@ EndFunction
 
 Function SelectFurniture()
 	ObjectReference[] Furnitures = OFurniture.FindFurniture(Actors.Length, Actors[0], (FurnitureSearchDistance + 1) * 100.0, 96)
-	If !SelectFurniture || !IsPlayerInvolved()
+	If !SelectFurniture
 		int i = 0
 		While i < Furnitures.Length
 			If Furnitures[i]
@@ -3104,7 +3047,7 @@ Event OnKeyDown(Int KeyPress)
 			return
 		EndIf
 	elseif (KeyPress == freecamkey)
-		if animationrunning() && IsPlayerInvolved()
+		if animationrunning()
 			ToggleFreeCam()
 			return
 		endif 
@@ -3598,4 +3541,16 @@ Function PrintBedInfo(ObjectReference Bed)
 	Console("BED - 3D loaded: " + Bed.Is3DLoaded())
 	Console("BED - Bed roll: " + IsBedRoll(Bed))
 	Console("--------------------------------------------")
+EndFunction
+
+Bool Function IsPlayerInvolved()
+	; NPC scenes no longer run on main thread ever. They will always run in subthreads
+	; Some addons might still use this function, so we'll keep it here for now
+	return True
+EndFunction
+
+Bool Function IsNPCScene()
+	; NPC scenes no longer run on main thread ever. They will always run in subthreads
+	; Some addons might still use this function, so we'll keep it here for now
+	return False
 EndFunction

--- a/Scripts/Source/_oActro.psc
+++ b/Scripts/Source/_oActro.psc
@@ -63,9 +63,15 @@ event onAlignTo(string eventName, string actorLocHub, float alignStyle, Form sen
 int style = alignStyle as int
 	if style == 0
 		align = true
-		OsexIntegrationMain OStim = OUtils.GetOStim()
-    	If OStim.UsingFurniture() && OStim.IsActorInvolved(Actra[0])
-    		ObjectReference FurnitureRef = OStim.GetFurniture()
+
+		; Event name will be something like 0SAO55_AlignTo
+		; So, split the name on the '_' character to get the Password reliably
+		string[] eventNameSplit = StringUtil.Split(eventName, "_")
+		int scenePassword = StringUtil.Substring(eventNameSplit[0], 4) as int
+
+		ObjectReference FurnitureRef = OSO.GetSceneFurniture(scenePassword, Actra[0])
+
+		If FurnitureRef != none
     		float X = FurnitureRef.GetPositionX()
     		float Y = FurnitureRef.GetPositionY()
     		float Z = FurnitureRef.GetPositionZ()

--- a/Scripts/Source/_oOmni.psc
+++ b/Scripts/Source/_oOmni.psc
@@ -261,10 +261,11 @@ Function PrepActra(String[] sceneSuite, Actor[] Actra)
         GlobalPosition[StageID].Delete()
     EndIf
 
-    OsexIntegrationMain OStim = OUtils.GetOStim()
-    If OStim.UsingFurniture() && OStim.IsActorInvolved(Actra[0])
-        GlobalPosition[StageID] = OStim.GetBed().PlaceAtMe(OBlankStatic) As ObjectReference
-        GlobalPosition[StageID].MoveTo(OStim.GetBed())
+    ObjectReference FurnitureRef = GetSceneFurniture(StageID, Actra[0])
+
+    If FurnitureRef != none
+        GlobalPosition[StageID] = FurnitureRef.PlaceAtMe(OBlankStatic) As ObjectReference
+        GlobalPosition[StageID].MoveTo(FurnitureRef)
     Else
         GlobalPosition[StageID] = Actra[0].PlaceAtMe(OBlankStatic) as ObjectReference
     EndIf
@@ -394,10 +395,11 @@ Function ActraReadyByKey(Actor[] Actra, String StageID, Int Index, Bool Solo = F
         GlobalPosition[StageIDInt].Delete()
     EndIf
 
-    OsexIntegrationMain OStim = OUtils.GetOStim()
-    If OStim.UsingFurniture() && OStim.IsActorInvolved(Actra[0])
-        GlobalPosition[StageIDint] = OStim.GetBed().PlaceAtMe(OBlankStatic) As ObjectReference
-        GlobalPosition[StageIDint].MoveTo(OStim.GetBed())
+    ObjectReference FurnitureRef = GetSceneFurniture(StageIDint, Actra[0])
+
+    If FurnitureRef != none
+        GlobalPosition[StageIDint] = FurnitureRef.PlaceAtMe(OBlankStatic) As ObjectReference
+        GlobalPosition[StageIDint].MoveTo(FurnitureRef)
     Else
         GlobalPosition[StageIDint] = Actra[0].PlaceAtMe(OBlankStatic) as ObjectReference
     EndIf
@@ -624,6 +626,29 @@ String[] Function SetOINI(Actor Player) Global
     Return OIN
 EndFunction
 
+ObjectReference Function GetSceneFurniture(int ScenePassword, actor Act)
+    OsexIntegrationMain OStim = OUtils.GetOStim()
 
+    if (OStim.GetScenePassword() == ScenePassword)
+        if (OStim.IsActorActive(Act))
+            return OStim.GetFurniture()
+        endif
 
+        return none
+    endif
 
+    int i = 0
+    int max = OStim.subthreadquest.GetNumAliases()
+
+    while i < max 
+        OStimSubthread thread = OStim.subthreadquest.GetNthAlias(i) as OStimSubthread
+
+        if (thread.IsInUse() && thread.GetScenePassword() == ScenePassword && OStim.IsActorActive(Act))
+            return thread.GetFurniture()
+        endif
+
+        i += 1
+    endwhile
+
+    return none
+EndFunction


### PR DESCRIPTION
Complete rewrite and overhaul of subthreads. List of changes/features:

- All NPC scenes are now automatically demoted to a subthread. This means main thread will only have a scene where the player is involved at any time.
- isPlayerInvolved() and IsNPCScene() functions moved to deprecated. They always return True and False, respectively, as a result of the above.
- Subthreads now send scene start, scene end and orgasm events like the main thread.
- Subthreads now have AI and will change animations dynamically like the main thread auto mode.
- Subthreads now support furniture. They will not use furniture automatically nor prompt a selection box to the user - addon makers will need to provide a furniture object reference for subthreads to use them.
- Subthreads now have proper actor rescaling.
- Excitement is now tracked in subthreads. Subthread scenes end automatically when dom, sub or both orgasm (respects MCM settings).
- Furniture alignment and translation is now made based on scene password to support subthreads.
- If an Actor in a Subthread is hit and therefore enters combat, the Subthread scene ends immediately, regardless of MCM settings.
- If an Actor in a Subhread dies, the Subthread scene ends immediately without crashing or any other issues.